### PR TITLE
script: option "-l" sets a language of message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ change log follows the conventions of
 
 ### Added
 
+- Option for setting language in a script.
+
 ### Fixed
 
 ### Changed

--- a/litclock
+++ b/litclock
@@ -15,27 +15,30 @@ set -eu -o pipefail
 
 PREFIX_DATA="/usr/local/share"
 
-DEFAULT_QUOTES="${PREFIX_DATA}/litclock/quotes_ru.csv"
+DEFAULT_LANG="ru"
 DELIM="|"
 DEFAULT_COLOR="\033[0;31m"
 DISABLE_COLOR="\e[0m"
 
-quotes_file="$DEFAULT_QUOTES"
+lang="${DEFAULT_LANG}"
 ctime=""
 
 usage() {
-	echo "Usage: $0 [-p <path>] [-t <time>] [-v]" 1>&2; exit 1;
+	echo "Usage: $0 [-p <path>] [-t <time>] [-l ru|en] [-v]" 1>&2; exit 1;
 }
 
-while getopts ":p:t:v" o; do
+while getopts ":p:t:l:v" o; do
     case "${o}" in
         p) quotes_file=${OPTARG} ;;
         t) ctime=${OPTARG} ;;
+        l) lang=${OPTARG} ;;
 		v) printf "litclock 0.1.0\n" && exit 0 ;;
         *) usage ;;
     esac
 done
 shift $((OPTIND-1))
+
+quotes_file="${PREFIX_DATA}/litclock/quotes_${lang}.csv"
 
 if ! [ -f "$quotes_file" ]; then
 	echo "File $quotes_file is not found."
@@ -55,7 +58,7 @@ do
 	if [ "$ctime" != "$time" ]; then
 		continue
 	fi
-	no_quote=""
+	no_quote=0
 	quote_time_case=$(echo "$line" | cut -d $DELIM -f2)
 	quote=$(echo "$line" | cut -d $DELIM -f3)
 	title=$(echo "$line" | cut -d $DELIM -f4)
@@ -76,6 +79,12 @@ do
 	break
 done
 
-! [ -z "$no_quote" ] && printf "No quote. Time is %s.\n" "$ctime"
+if [ $no_quote -eq 1 ]; then
+    if [ "X$lang" == "Xru" ]; then
+        printf "Счастливые часов не наблюдают. (сейчас %s)\n" "$ctime"
+    else
+        printf "No quote. Time is %s.\n" "$ctime"
+    fi
+fi
 
 exit 0

--- a/litclock.1
+++ b/litclock.1
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2022, Sergey Bronnikov
+.\" Copyright (c) 2022-2023, Sergey Bronnikov
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@
 .Nm
 .Op Fl p Ar path
 .Op Fl t Ar time
+.Op Fl l Ar lang
 .Op Fl v
 .Sh DESCRIPTION
 .Nm
@@ -46,6 +47,10 @@ The options are as follows:
 Specify a path to a file with quotes.
 .It Fl t Ar time
 Specify a time a format HH:MM to use instead of current time.
+.It Fl l Ar lang
+Specify a language.
+Possible values are "ru" and "en".
+Default language is "ru".
 .El
 .Sh EXAMPLES
 Display a quote for a current time:
@@ -54,6 +59,10 @@ $ litclock
 .Pp
 "9:05am lay in bed, staring at ceiling"
  -- 'A Fraction of the Whole', Steve Toltz
+.Pp
+$ litclock -l ru -t 23:16
+.Pp
+Счастливые часов не наблюдают. (сейчас 23:16)
 .Sh AUTHORS
 .Nm
 was written by


### PR DESCRIPTION
```
$ litclock -t 23:16
Счастливые часов не наблюдают. (сейчас 23:16)
$ litclock -t 09:16
"09:16: Утро тринадцатого февраля, которое, - читатели сего правдивого повествования знают это не хуже, чем мы, - было кануном дня, назначен
 ого для слушания дела миссис Бардл, оказалось беспокойным для мистера Сэмюела Уэллера, непрерывно путешествовавшего от "Джорджа и Ястреба" 
  дому мистера Перкера и обратно с девяти часов утра и до двух часов дня включительно."
 -- 'Посмертные записки Пиквикского Клуба', Чарльз Диккенс

$ litclock -t 09:32 -l en
"He said he couldn't say for certain of course, but that he rather thought he was. Anyhow, if he wasn't the 11.5 for Kingston, he said he was pretty confident he was the 9.32 for Virginia Water, or the 10 a.m. express for the Isle of Wight, or somewhere in that direction, and we should all know when we got there."
 -- 'Three Men in a Boat', Jerome K. Jerome

$ 
```